### PR TITLE
Expose tiler options via command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next
 
+* [#6](https://github.com/dblock/dzt/pull/7) Expose all tiler and storage options via command line - [@mzikherman](https://github.com/mzikherman)
 * [#5](https://github.com/dblock/dzt/pull/5) Allow a Fog::Storage uploader to be passed in for uploading of generated tiles rather than local storage - [@mzikherman](https://github.com/mzikherman)
 
 ### 0.1.0 (3/16/2014)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,21 @@ dzt help
 dzt slice image.jpg --output tiles
 ```
 
-Creates a *tiles* folder with deep-zoom tiles.
+Creates a *tiles* folder with deep-zoom tiles. This will use the defaults defined in [https://github.com/dblock/dzt/blob/master/lib/dzt/tiler.rb)(https://github.com/dblock/dzt/blob/master/lib/dzt/tiler.rb#L7-L10)
+
+You can pass in flags to override all these options, such as:
+
+```
+dzt slice image.jpg --output=tiles --format=90 --tile-format=png
+```
+
+Additionally, you can have generated files uploaded to S3 for you. You can specify that like:
+
+```
+dzt slice image.jpg --acl=public-read --bucket=bucket --s3-key=prefix --aws-id=id --aws-secret=secret
+```
+
+The files will be uploaded to the bucket specified, and generated files will be prefixed by the s3 key.
 
 
 ## Contributing

--- a/bin/dzt
+++ b/bin/dzt
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'gli'
 require 'dzt'
+require 'fog'
 
 include GLI::App
 
@@ -10,16 +11,41 @@ default_command :slice
 
 desc "Slice an image"
 command :slice do |c|
-  c.flag [:o, :output], desc: 'Output folder', default_value: File.join(Dir.pwd, "tiles")
+  c.flag [:o, :output, 'output'], desc: 'Output folder'
+  c.flag [:ts, :tilesize, 'tile-size'], desc: 'Tile size', default_value: DZT::Tiler::DEFAULT_TILE_SIZE
+  c.flag [:to, :tileoverlap, 'tile-overlap'], desc: 'Tile overlap', default_value: DZT::Tiler::DEFAULT_TILE_OVERLAP
+  c.flag [:q, :quality], desc: 'Output quality', default_value: DZT::Tiler::DEFAULT_QUALITY
+  c.flag [:f, :format], desc: 'Tile format', default_value: DZT::Tiler::DEFAULT_TILE_FORMAT
+  c.flag [:overwrite], desc: 'Overwrite output files', default_value: DZT::Tiler::DEFAULT_OVERWRITE_FLAG
+  c.flag [:acl], desc: 'S3 Acl', default_value: DZT::S3Storage::DEFAULT_ACL
+  c.flag [:bucket], desc: 'S3 Bucket'
+  c.flag [:s3_key, 's3-key'], desc: 'S3 Key', default_value: DZT::S3Storage::DEFAULT_KEY
+  c.flag [:aws_id, 'aws-id'], desc: 'AWS Id'
+  c.flag [:aws_secret, 'aws-secret'], desc: 'AWS Secret'
   c.action do |global_options, options, args|
     if args.length < 1
       raise 'You must specify an image file to slice.'
     end
-    storage = DZT::FileStorage.new(
-      destination: options[:output]
-    )
+    if options[:output]
+      storage = DZT::FileStorage.new(
+        destination: options[:output]
+      )
+    else
+      storage = DZT::S3Storage.new(
+        s3_acl: options[:acl],
+        s3_bucket: options[:bucket],
+        s3_key: options[:s3_key],
+        aws_id: options[:aws_id],
+        aws_secret: options[:aws_secret]
+      )
+    end
     tiler = DZT::Tiler.new(
       source: args[0],
+      size: options[:tilesize],
+      overlap: options[:tileoverlap],
+      format: options[:format],
+      quality: options[:quality],
+      overwrite: options[:overwrite],
       storage: storage
     )
     tiler.slice! do |path|

--- a/lib/dzt/s3_storage.rb
+++ b/lib/dzt/s3_storage.rb
@@ -1,5 +1,7 @@
 module DZT
   class S3Storage
+    DEFAULT_ACL = 'public-read'
+    DEFAULT_KEY = ''
     #
     # @param s3_acl: ACL to use for storing, defaults to 'public-read'.
     # @param s3_bucket: Bucket to store tiles.
@@ -8,9 +10,9 @@ module DZT
     # @param aws_secret: AWS Secret.
     #
     def initialize(options = {})
-      @s3_acl = options[:s3_acl] || 'public-read'
+      @s3_acl = options[:s3_acl] || DEFAULT_ACL
       @s3_bucket = options[:s3_bucket]
-      @s3_key = options[:s3_key]
+      @s3_key = options[:s3_key] || DEFAULT_KEY
       @s3_id = options[:aws_id]
       @s3_secret = options[:aws_secret]
     end
@@ -38,7 +40,7 @@ module DZT
 
     def write(file, dest, options = {})
       quality = options[:quality]
-      @s3.put_object(@s3_bucket, dest, file.to_blob { @quality = quality if quality },
+      s3.put_object(@s3_bucket, dest, file.to_blob { @quality = quality if quality },
         'Content-Type' => file.mime_type,
         'x-amz-acl' => @s3_acl
       )

--- a/lib/dzt/tiler.rb
+++ b/lib/dzt/tiler.rb
@@ -8,6 +8,7 @@ module DZT
     DEFAULT_TILE_OVERLAP = 0
     DEFAULT_QUALITY = 75
     DEFAULT_TILE_FORMAT = "jpg"
+    DEFAULT_OVERWRITE_FLAG = false
 
     # Generates the DZI-formatted tiles and sets necessary metadata on this object.
     #
@@ -32,7 +33,7 @@ module DZT
       @max_tiled_width = @tile_source.columns
 
       @tile_quality = options[:quality] || DEFAULT_QUALITY
-      @overwrite = options[:overwrite] || false
+      @overwrite = options[:overwrite] || DEFAULT_OVERWRITE_FLAG
       @storage = options[:storage]
     end
 

--- a/spec/dzt/dzt_spec.rb
+++ b/spec/dzt/dzt_spec.rb
@@ -1,4 +1,6 @@
 require 'spec_helper'
+require 'RMagick'
+include Magick
 
 describe DZT do
   before :each do
@@ -12,15 +14,44 @@ describe DZT do
     end
   end
   describe "#slice" do
-    it "slices an image" do
-      goya = File.join(@fixtures_dir, "francisco-jose-de-goya-y-lucientes-senora-sabasa-garcia.jpg")
-      Dir.mktmpdir do |tmpdir|
-        `"#{@binary}" slice "#{goya}" --output #{tmpdir}`
-        expect(Dir["#{tmpdir}/*"].map { |dir| dir.split("/").last.to_i }.sort).to eq((0..12).to_a)
-        # center
-        image = Magick::Image::read("#{tmpdir}/11/1_1.jpg").first
+    context 'storing files locally' do
+      it "slices an image" do
+        goya = File.join(@fixtures_dir, "francisco-jose-de-goya-y-lucientes-senora-sabasa-garcia.jpg")
+        Dir.mktmpdir do |tmpdir|
+          `"#{@binary}" slice "#{goya}" --output #{tmpdir}`
+          expect(Dir["#{tmpdir}/*"].map { |dir| dir.split("/").last.to_i }.sort).to eq((0..12).to_a)
+          # center
+          image = Magick::Image::read("#{tmpdir}/11/1_1.jpg").first
+          expect(image.columns).to eq(512)
+          expect(image.rows).to eq(512)
+        end
+      end
+    end
+    context 'uploading to S3' do
+      before :each do
+        Fog.mock!
+        Fog::Mock.reset
+        s3 = Fog::Storage.new(
+          provider: 'AWS',
+          aws_access_key_id: 'id',
+          aws_secret_access_key: 'secret'
+        )
+        @bucket = s3.directories.create(key: 'tiled-images')
+      end
+      xit 'slices the images and stores them' do
+        goya = File.join(@fixtures_dir, "francisco-jose-de-goya-y-lucientes-senora-sabasa-garcia.jpg")
+        expect_any_instance_of(Fog::Storage::AWS::Mock).to receive(:put_object).at_least(53).times do |*args|
+          expect(args.last).to eq("Content-Type" => "image/jpeg", "x-amz-acl" => "public-read")
+        end
+        `"#{@binary}" slice "#{goya}" --acl=public-read --bucket=tiled-images --s3-key=dztiles --aws-id=id --aws-secret=secret`
+        file = @bucket.files.select { |f| f.key == 'dztiles/11/1_1.jpg' }.first
+        image = Image.from_blob(file.body).first
         expect(image.columns).to eq(512)
         expect(image.rows).to eq(512)
+        file = @bucket.files.select { |f| f.key == 'dztiles/11/2_2.jpg' }.first
+        image = Image.from_blob(file.body).first
+        expect(image.columns).to eq(168)
+        expect(image.rows).to eq(443)
       end
     end
   end


### PR DESCRIPTION
This exposes all the options to tiler (both storage and tiling) to the command line.

I am having an issue with specc'ing the S3 part. It seems as though `Fog.mock!`, required for testing, is not registering when called in a `before` and then running the binary. Perhaps the execution of the `dzt` binary is happening in a different thread?

I left the spec pending for now, I did run this from the command line and verify that it worked.

![screen shot 2014-10-17 at 12 40 09 pm](https://cloud.githubusercontent.com/assets/1457859/4682333/e3043b9e-561b-11e4-9932-895e8452ecdd.png)
